### PR TITLE
Removed fs dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,5 @@
   "homepage": "https://github.com/pndgz/express-mustache#readme",
   "dependencies": {
     "mustache": "^2.2.1",
-    "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/pndgz/express-mustache#readme",
   "dependencies": {
-    "fs": "0.0.2",
     "mustache": "^2.2.1",
     "path": "^0.12.7"
   }


### PR DESCRIPTION
Heya, just as a heads up - fs package in npm is a spam/placeholder. The fs module is built-in so there is no need to explicitly add it to the dependency list. There's more info on this here: https://www.npmjs.com/package/fs and here: http://status.npmjs.org/incidents/dw8cr1lwxkcr. 😃